### PR TITLE
Updated README to clarify running application is required for e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 # production
 /build
 
+# ide
+.idea
+
 # misc
 .DS_Store
 .env.local

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 This is a create-react-app scaffolded project designed as a kata for test automation.
 
-- yarn install
-- yarn start
-- yarn run e2e
+- ```yarn install```
+- ```yarn start```
+- ```yarn run e2e```
 
 ## Manual execution
 1. Open up browser tabs for:
-  - [http://localhost:3000/](http://localhost:3000/)
+    - [http://localhost:3000/](http://localhost:3000/)
 2. Open features/todo.feature in your IDE
 3. Review [Cucumber](https://cucumber.io/docs/reference)
 4. Walk through the todo.feature file manually
@@ -14,8 +14,9 @@ This is a create-react-app scaffolded project designed as a kata for test automa
 
 ## Connect to automation
 1. Open up API Documentation
-  - [Nightwatch Commands API](http://nightwatchjs.org/api#commands)
+    - [Nightwatch Commands API](http://nightwatchjs.org/api#commands)
 2. Open features/step_definitions/steps.js
-3. Open terminal and run the ```yarn run e2e``` command
-4. Show how the Given step maps to the the steps.js file Given() block
-5. Progressively complete the wiring between the feature file and the steps file.
+3. Open terminal and run ```yarn start``` if not currently running
+4. Open new terminal and run the ```yarn run e2e``` command
+5. Show how the Given step maps to the the steps.js file Given() block
+6. Progressively complete the wiring between the feature file and the steps file.

--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -1,10 +1,10 @@
 const { client } = require("nightwatch-cucumber");
-const { Given, Then, When } = require("cucumber");
+const { Given, When, Then } = require("cucumber");
 
 Given(/^There are no existing todos$/, () => {
   const todoPage = client.page.todo();
 
   return todoPage.navigate().waitForElementVisible("@body", 1000);
 });
-Then(/^I add a new todo$/, () => {});
+When(/^I add a new todo$/, () => {});
 Then(/^A new, incomplete todo should be added to my list$/, () => {});


### PR DESCRIPTION
- Worked through the kata, after much pain and agony, I realized I was not running the application. I have updated the `README.md` to inform the user of running the application prior to running the e2e tests (in separate terminals)
- Fixed some nitpicky Given/When/Then usage
- Cleaned up the `README.md` nested tab styling 

Before:
<img width="300" alt="screen shot 2018-05-09 at 10 25 54 pm" src="https://user-images.githubusercontent.com/9942473/39848965-074faf16-53d8-11e8-9d4b-412d0ec27a1c.png">
After:
<img width="300" alt="screen shot 2018-05-09 at 10 26 04 pm" src="https://user-images.githubusercontent.com/9942473/39848967-09952594-53d8-11e8-9b87-5b0824151145.png">

